### PR TITLE
Ls memory usage

### DIFF
--- a/nes-memory/BufferManager.cpp
+++ b/nes-memory/BufferManager.cpp
@@ -20,10 +20,13 @@
 #include <cstdio>
 #include <cstring>
 #include <deque>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <memory_resource>
 #include <mutex>
 #include <optional>
+#include <thread>
 #include <utility>
 #include <unistd.h>
 #include <Runtime/AbstractBufferProvider.hpp>
@@ -42,7 +45,9 @@ BufferManager::BufferManager(
     const uint32_t bufferSize,
     const uint32_t numOfBuffers,
     std::shared_ptr<std::pmr::memory_resource> memoryResource,
-    const uint32_t withAlignment)
+    const uint32_t withAlignment,
+    std::optional<std::filesystem::path> monitorFilePath,
+    std::chrono::milliseconds monitorInterval)
     : availableBuffers(numOfBuffers)
     , numOfAvailableBuffers(numOfBuffers)
     , unpooledChunksManager(std::make_shared<UnpooledChunksManager>(memoryResource))
@@ -52,6 +57,42 @@ BufferManager::BufferManager(
 {
     ((void)withAlignment);
     initialize(DEFAULT_ALIGNMENT);
+
+    /// Start buffer usage monitoring thread if a file path is provided.
+    /// The thread uses a pointer to numOfAvailableBuffers which is safe because:
+    /// monitorThread is the last member, so it's destroyed first. The jthread destructor
+    /// requests stop and joins, ensuring the thread exits before other members are destroyed.
+    if (monitorFilePath.has_value())
+    {
+        monitorThread = std::jthread(
+            [availableBuffersPtr = &numOfAvailableBuffers,
+             interval = monitorInterval,
+             totalBuffers = numOfBuffers,
+             path = std::move(monitorFilePath.value())](const std::stop_token& stopToken)
+            {
+                std::ofstream file(path);
+                if (!file.is_open())
+                {
+                    return;
+                }
+                file << "timestamp_ms,used_buffers\n";
+
+                while (!stopToken.stop_requested())
+                {
+                    std::this_thread::sleep_for(interval);
+                    if (stopToken.stop_requested())
+                    {
+                        break;
+                    }
+                    const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                         std::chrono::system_clock::now().time_since_epoch())
+                                         .count();
+                    const auto available = availableBuffersPtr->load();
+                    const auto used = totalBuffers - available;
+                    file << now << "," << used << "\n";
+                }
+            });
+    }
 }
 
 void BufferManager::destroy()
@@ -111,9 +152,15 @@ void BufferManager::destroy()
 }
 
 std::shared_ptr<BufferManager> BufferManager::create(
-    uint32_t bufferSize, uint32_t numOfBuffers, const std::shared_ptr<std::pmr::memory_resource>& memoryResource, uint32_t withAlignment)
+    uint32_t bufferSize,
+    uint32_t numOfBuffers,
+    const std::shared_ptr<std::pmr::memory_resource>& memoryResource,
+    uint32_t withAlignment,
+    std::optional<std::filesystem::path> monitorFilePath,
+    std::chrono::milliseconds monitorInterval)
 {
-    return std::make_shared<BufferManager>(Private{}, bufferSize, numOfBuffers, memoryResource, withAlignment);
+    return std::make_shared<BufferManager>(
+        Private{}, bufferSize, numOfBuffers, memoryResource, withAlignment, std::move(monitorFilePath), monitorInterval);
 }
 
 BufferManager::~BufferManager()

--- a/nes-memory/include/Runtime/BufferManager.hpp
+++ b/nes-memory/include/Runtime/BufferManager.hpp
@@ -17,10 +17,12 @@
 #include <atomic>
 #include <condition_variable>
 #include <deque>
+#include <filesystem>
 #include <memory>
 #include <memory_resource>
 #include <mutex>
 #include <optional>
+#include <thread>
 #include <vector>
 #include <Runtime/AbstractBufferProvider.hpp>
 #include <Runtime/Allocator/NesDefaultMemoryAllocator.hpp>
@@ -76,18 +78,24 @@ public:
         uint32_t bufferSize,
         uint32_t numOfBuffers,
         std::shared_ptr<std::pmr::memory_resource> memoryResource,
-        uint32_t withAlignment);
+        uint32_t withAlignment,
+        std::optional<std::filesystem::path> monitorFilePath,
+        std::chrono::milliseconds monitorInterval);
 
     /// Creates a new global buffer manager
     /// @param bufferSize the size of each buffer in bytes
     /// @param numOfBuffers the total number of buffers in the pool
     /// @param withAlignment the alignment of each buffer, default is 64 so ony cache line aligned buffers, This value must be a pow of two and smaller than page size
     /// @param memoryResource resource for allocating and deallocating memory
+    /// @param monitorFilePath optional path to log buffer usage statistics
+    /// @param monitorInterval interval between buffer usage samples (default 100ms)
     static std::shared_ptr<BufferManager> create(
         uint32_t bufferSize = DEFAULT_BUFFER_SIZE,
         uint32_t numOfBuffers = DEFAULT_NUMBER_OF_BUFFERS,
         const std::shared_ptr<std::pmr::memory_resource>& memoryResource = std::make_shared<NesDefaultMemoryAllocator>(),
-        uint32_t withAlignment = DEFAULT_ALIGNMENT);
+        uint32_t withAlignment = DEFAULT_ALIGNMENT,
+        std::optional<std::filesystem::path> monitorFilePath = "buffer_usage.csv",
+        std::chrono::milliseconds monitorInterval = std::chrono::milliseconds{100});
 
     BufferManager(const BufferManager&) = delete;
     BufferManager& operator=(const BufferManager&) = delete;
@@ -179,6 +187,9 @@ private:
 
     std::shared_ptr<std::pmr::memory_resource> memoryResource;
     std::atomic<bool> isDestroyed{false};
+
+    /// Buffer usage monitoring thread
+    std::jthread monitorThread;
 };
 
 

--- a/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorSource.cpp
@@ -69,7 +69,7 @@ void GeneratorSource::open()
 
 void GeneratorSource::close()
 {
-    auto totalElapsedTime = std::chrono::high_resolution_clock::now() - generatorStartTime;
+    auto totalElapsedTime = std::chrono::system_clock::now() - generatorStartTime;
     NES_TRACE("Generated {} buffers in {}. Closing GeneratorSource.", generatedBuffers, totalElapsedTime);
 }
 
@@ -135,7 +135,7 @@ size_t GeneratorSource::fillTupleBuffer(NES::Memory::TupleBuffer& tupleBuffer, c
         /// Calculating how long to sleep. The whole method should take the duration of the flushInterval. If we have some time left, we
         /// sleep for the remaining duration. If there is no time left, we print a warning.
         const auto durationGeneratingTuples
-            = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - startOfInterval);
+            = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - startOfInterval);
         if (durationGeneratingTuples > (flushInterval * noIntervals))
         {
             NES_WARNING(

--- a/nes-single-node-worker/src/LatencyListener.cpp
+++ b/nes-single-node-worker/src/LatencyListener.cpp
@@ -43,7 +43,7 @@ struct TaskIntermediateStore
     }
 
     explicit TaskIntermediateStore()
-        : queryId(INVALID_QUERY_ID), bytes(0), numberOfTuples(0), startTimePoint(std::chrono::high_resolution_clock::now())
+        : queryId(INVALID_QUERY_ID), bytes(0), numberOfTuples(0), startTimePoint(std::chrono::system_clock::now())
     {
     }
 
@@ -55,7 +55,7 @@ struct TaskIntermediateStore
 
 struct TimestampAndLatencies
 {
-    explicit TimestampAndLatencies() : firstTimePoint(std::chrono::high_resolution_clock::now()) { }
+    explicit TimestampAndLatencies() : firstTimePoint(std::chrono::system_clock::now()) { }
 
     ChronoClock::time_point firstTimePoint;
     std::vector<std::chrono::duration<double>> latencies;
@@ -158,7 +158,7 @@ void LatencyListener::onNodeShutdown()
 {
     /// We wait until the queue is empty or for 30 seconds
     const std::chrono::seconds timeout{30};
-    const auto endTime = std::chrono::high_resolution_clock::now() + timeout;
+    const auto endTime = std::chrono::system_clock::now() + timeout;
     while (true)
     {
         /// Check if the queue is empty
@@ -168,7 +168,7 @@ void LatencyListener::onNodeShutdown()
         }
 
         /// Check if the timeout has been reached
-        if (std::chrono::high_resolution_clock::now() >= endTime)
+        if (std::chrono::system_clock::now() >= endTime)
         {
             std::cout << fmt::format(
                 "Queue in ThroughputListener still contains {} elements but could not finish in {}.", events.rlock()->size(), timeout)


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
**(for example:)** 
This pull request adds support for variable sized data to the nested loop join. The change list is as follows:
- Added a `write()` and `read()` method to the `PagedVector` that supports variable sized data.
- Changed the `NLJBuild` to call the `write()` method when adding a tuple to the `PagedVector`.
- Changed the `NLJProbe` to call the `read()` method when reading a tuple from the `PagedVector`.

## Verifying this change
This change is tested by
*(for example:)*
- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after main failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*

## What components does this pull request potentially affect?
*(for example:)*
- Dependencies (does it add or upgrade a dependency)
- ExecutionEngine
- QueryCompiler
- QueryEngine
- RestAPI

## Documentation
- The change is reflected in the necessary documentation, e.g., design document, in-code documentation.
- All necessary methods (no getter, setter, or constructor) have a documentation.

## Issue Closed by this pull request:

This PR closes #<issue number>
